### PR TITLE
main

### DIFF
--- a/server/models/SessionModel.js
+++ b/server/models/SessionModel.js
@@ -22,7 +22,7 @@ const Session = ({
     track_url,
     organization,
     bulk_pack_file_name: key,
-    start_time: new Date(start_time).toISOString(), // TEMPORARY FOR MOBILE FIX FOR TEST ENVIRONMENT
+    start_time,
     bulk_pack_version: 'v2',
   });
 

--- a/server/models/SessionModel.spec.js
+++ b/server/models/SessionModel.spec.js
@@ -11,7 +11,7 @@ const config = require('../../config/config');
 
 describe('Session Model', () => {
   it('Session Models should return defined fields', () => {
-    const session = Session({ start_time: 1683018302447 });
+    const session = Session({});
     expect(session).to.have.keys([
       'id',
       'device_configuration_id',
@@ -36,7 +36,7 @@ describe('Session Model', () => {
       track_url: 'track_url',
       organization: 'organization',
       key: 'bulk_pack_file_name',
-      start_time: 1683018302447,
+      start_time: new Date().toISOString(),
     };
 
     const axiosStub = sinon.stub(axios, 'post');
@@ -49,7 +49,6 @@ describe('Session Model', () => {
       ...sessionObject,
       bulk_pack_file_name: 'bulk_pack_file_name',
       bulk_pack_version: 'v2',
-      start_time: new Date(1683018302447).toISOString(),
     });
     axiosStub.restore();
     sessionUrlStub.restore();


### PR DESCRIPTION
- fix: rotation_matrix
- chore(release): 1.2.9 [skip ci]
- feat: switch back to ISO data for v2
- chore(release): 1.3.0 [skip ci]
- fix: rename prod to production
- chore(release): 1.3.1 [skip ci]
- fix: improve debug message
- fix: improve debug message
- chore(release): 1.3.2 [skip ci]
- fix: message_uuid should be called id
- chore(release): 1.3.3 [skip ci]
- fix: change answers to survey_response
- fix: force deployment
- fix: force deployment
- chore(release): 1.3.4 [skip ci]
- fix: add default image url
- chore(release): 1.3.5 [skip ci]
- fix: default image url
- chore(release): 1.3.6 [skip ci]
- fix: send bulk pack file name to the various microservices
- chore: fix tests
- chore: github workflow checks
- chore(release): 1.3.7 [skip ci]
- chore: no longer need docker pull image secret
- chore: remove docker pull secret
- chore: convert to argocd
- chore: bump docker image tag 1.3.7)} [skip ci]
- fix: rotation_matrix
- chore(release): 1.3.8 [skip ci]
- chore: bump docker image tag 1.3.8 [skip ci]
- fix: add session start_time and re_tracking
- fix: fix tests
- chore(release): 1.3.9 [skip ci]
- chore: bump docker image tag 1.3.9 [skip ci]
- Revert "fix/updates"
- fix: start_time
- chore: start_time test
- chore(release): 1.3.10 [skip ci]
- chore: bump docker image tag 1.3.10 [skip ci]
- fix: add bulk pack version
- fix: semantic release
- fix: start_time temp fix
- chore: fix test
- fix: revert
